### PR TITLE
Image drawer, slightly cleaned color picker, converted into arguments instead of accessing global variables, relocate inline scripts into canvas-commons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# canvas-app
-
-# HTML canvas used to draw graphics on a web page.
-
 # Canvas app
 
 HTML5 web app used to draw graphics via scripting in JavaScript.

--- a/index.html
+++ b/index.html
@@ -128,12 +128,7 @@
                             Retrive Image
                         </span>
                     </div>
-                    <div class="row">
-                        <span class="btn btn-primary" id="testingbutton">
-                            <i class="fas fa-pencil-alt"></i>
-                            Test Button
-                        </span>
-                    </div>
+                    <input id = "dr-img" type="file"  accept="image/*">
                     <!-- Color picker tester -->
                     <input type='text' id="custom" />
                 </div>
@@ -190,6 +185,7 @@
     <script type='text/javascript' src="./scripts/color-picker.js"></script>
     <script type='text/javascript' src="./scripts/image-storage.js"></script>
     <script type='text/javascript' src="./scripts/reset.js"></script>
+    <script src="./scripts/image-drawer.js"></script>
 
     <script type='text/javascript '>
         currentFunction = new Pencil(contextReal, contextDraft);

--- a/index.html
+++ b/index.html
@@ -99,37 +99,24 @@
                         </span>
                     </div>
                     <div class="row">
+                        <span class="btn btn-primary" id="img-fill">
+                            <i class="fas fa-retweet"></i>
+                            Fill w/ Image
+                        </span>
+                    </div>
+                    <div class="row">
                         <span class="btn btn-danger" id="reset">
                             <i class="fas fa-sync"></i>
                             Reset
                         </span>
                     </div>
                     <div class="row">
-                        <span class="btn position-relative col-pic" id="stroke">Stroke Color
-                        </span>
-                    </div>
-                    <div class="row">
                         <span class="btn position-relative col-pic" id="fill">Fill Color
                         </span>
                     </div>
-                    <div class="row">
-                        <span class="btn position-relative col-pic" id="bgc">Background Color
-                        </span>
-                    </div>
-                    <div class="row">
-                        <span class="btn btn-primary" id="test">
-                            <i class="fas fa-pencil-alt"></i>
-                            Testing Retrive
-                        </span>
-                    </div>
-                    <div class="row">
-                        <span class="btn btn-primary" id="retrive">
-                            <i class="fas fa-pencil-alt"></i>
-                            Retrive Image
-                        </span>
-                    </div>
+
+                    <!-- Testing with color picker and image picker -->
                     <input id = "dr-img" type="file"  accept="image/*">
-                    <!-- Color picker tester -->
                     <input type='text' id="custom" />
                 </div>
             </nav>
@@ -174,6 +161,8 @@
     <script type="text/javascript" src="./scripts/spectrum.js"></script>
     <script type='text/javascript' src="./scripts/canvas-common.js"></script>
     <script type='text/javascript' src="./scripts/brush-size.js"></script>
+    <script type='text/javascript' src="./scripts/image-storage.js"></script>
+    <script type='text/javascript' src="./scripts/image-drawer.js"></script>
     <script type='text/javascript' src="./scripts/pencil.js"></script>
     <script type='text/javascript' src="./scripts/eraser.js"></script>
     <script type='text/javascript' src="./scripts/line.js"></script>
@@ -183,42 +172,11 @@
     <script type='text/javascript' src="./scripts/circle-fill.js"></script>
     <script type='text/javascript' src="./scripts/polygon.js"></script>
     <script type='text/javascript' src="./scripts/color-picker.js"></script>
-    <script type='text/javascript' src="./scripts/image-storage.js"></script>
+    <script type='text/javascript' src="./scripts/text.js"></script>
     <script type='text/javascript' src="./scripts/reset.js"></script>
-    <script src="./scripts/image-drawer.js"></script>
+    
 
-    <script type='text/javascript '>
-        currentFunction = new Pencil(contextReal, contextDraft);
 
-        $('#pencil').click(() => {
-            currentFunction = new Pencil(contextReal, contextDraft);
-        });
-        $('#eraser').click(() => {
-            currentFunction = new Eraser(contextReal, contextDraft);
-        });
-        $('#rectangle').click(() => {
-            currentFunction = new Rectangle(contextReal, contextDraft);
-        });
-        $('#rectangle-fill').click(() => {
-            currentFunction = new RectangleFill(contextReal, contextDraft);
-        });
-        $('#circle').click(() => {
-            currentFunction = new Circle(contextReal, contextDraft);
-        });
-        $('#circle-fill').click(() => {
-            currentFunction = new CircleFill(contextReal, contextDraft);
-        });
-        $('#line').click(() => {
-            currentFunction = new Line(contextReal, contextDraft);
-        });
-        $('#polygon').click(() => {
-            currentFunction = new Polygon(contextReal, contextDraft);
-        });
-        $('#reset').click(() => {
-            currentFunction = new Reset(contextReal, contextDraft);
-            currentFunction = new Pencil(contextReal, contextDraft);
-        });
-    </script>
 </body>
 
 </html>

--- a/scripts/brush-size.js
+++ b/scripts/brush-size.js
@@ -1,7 +1,3 @@
-let canvasSettings = {
-    //   brushSize: $('#brushSize').val(),
-    brushSize: 1,
-}
 $("#brushSize :input").change(function () {
     if (this.id == 'brushSize-xs') {
         canvasSettings.brushSize = 1;

--- a/scripts/canvas-common.js
+++ b/scripts/canvas-common.js
@@ -6,61 +6,87 @@ const contextDraft = canvasDraft.getContext('2d');
 let currentFunction;
 let dragging = false;
 
-
-let style = {
-  // "strokeWth": 20,
-  "joint": "round",
-  "curCol": {
-    "stroke": "#fff228",
-    "fill": "#244a73",
-    "bgc": "#FFFFFF"
+// Styling setting of canvas, applicable to both draft and real canvas(s)
+let canvasSettings = {
+  brushSize: 1,
+  joint: "round",
+  curCol: {
+      stroke: "#fff228",
+      fill: "#244a73",
+      bgc: "#FFFFFF"
   },
-  "txt": {
-    "size": "48px",
-    "fontfamily": "serif"
+  txt: {
+      size: "48px",
+      fontfamily: "serif"
   }
 }
 
+// Initiate canvas function when clicking corresponding button on canvas
+currentFunction = new Pencil(contextReal, contextDraft);
 
+$('#pencil').click(() => {
+  currentFunction = new Pencil(contextReal, contextDraft);
+});
+$('#eraser').click(() => {
+  currentFunction = new Eraser(contextReal, contextDraft);
+});
+$('#rectangle').click(() => {
+  currentFunction = new Rectangle(contextReal, contextDraft);
+});
+$('#rectangle-fill').click(() => {
+  currentFunction = new RectangleFill(contextReal, contextDraft);
+});
+$('#circle').click(() => {
+  currentFunction = new Circle(contextReal, contextDraft);
+});
+$('#circle-fill').click(() => {
+  currentFunction = new CircleFill(contextReal, contextDraft);
+});
+$('#line').click(() => {
+  currentFunction = new Line(contextReal, contextDraft);
+});
+$('#polygon').click(() => {
+  currentFunction = new Polygon(contextReal, contextDraft);
+});
+$('#img-fill').click(() => {
+  currentFunction = new ImageFill(contextReal, contextDraft, deImage);
+});
+$('#reset').click(() => {
+  currentFunction = new Reset(contextReal, contextDraft);
+  currentFunction = new Pencil(contextReal, contextDraft);
+});
 
-
-
-$(window).on("keydown", (event)=> {
-  if (event.keyCode == 107 ){
-    console.log("click:)");
-    retriveImage(storeImg);
-  }
-})
+// receiving input when performing mouse activity
 
 $('#canvas-draft').mousedown(e => {
   const mouseLoc = [e.offsetX, e.offsetY];
-  currentFunction.onMouseDown(mouseLoc, e, style);
+  currentFunction.onMouseDown(mouseLoc, e, canvasSettings);
   dragging = true;
 });
 
 $('#canvas-draft').mousemove(e => {
   const mouseLoc = [e.offsetX, e.offsetY];
   if (dragging) {
-    currentFunction.onDragging(mouseLoc, e, style);
+    currentFunction.onDragging(mouseLoc, e, canvasSettings);
   }
-  currentFunction.onMouseMove(mouseLoc, e, style);
+  currentFunction.onMouseMove(mouseLoc, e, canvasSettings);
 });
 
 $('#canvas-draft').mouseup(e => {
   dragging = false;
   const mouseLoc = [e.offsetX, e.offsetY];
-  currentFunction.onMouseUp(mouseLoc, e, style);
+  currentFunction.onMouseUp(mouseLoc, e, canvasSettings);
 });
 
 $('#canvas-draft').mouseleave(e => {
   dragging = false;
   const mouseLoc = [e.offsetX, e.offsetY];
-  currentFunction.onMouseLeave(mouseLoc, e, style);
+  currentFunction.onMouseLeave(mouseLoc, e, canvasSettings);
 });
 
 $('#canvas-draft').mouseenter(e => {
   const mouseLoc = [e.offsetX, e.offsetY];
-  currentFunction.onMouseEnter(mouseLoc, e, style);
+  currentFunction.onMouseEnter(mouseLoc, e, canvasSettings);
 });
 
 class PaintFunction {

--- a/scripts/canvas-common.js
+++ b/scripts/canvas-common.js
@@ -5,7 +5,7 @@ const contextDraft = canvasDraft.getContext('2d');
 
 let currentFunction;
 let dragging = false;
-let storeImg = HTMLImageElement;
+
 
 let style = {
   // "strokeWth": 20,
@@ -22,13 +22,15 @@ let style = {
 }
 
 
-$("#test").click(()=>{
-  saveImage(canvasReal);
-});
-$("#retrive").click(()=>{
-  retriveImage(storeImg);
-});
 
+
+
+$(window).on("keydown", (event)=> {
+  if (event.keyCode == 107 ){
+    console.log("click:)");
+    retriveImage(storeImg);
+  }
+})
 
 $('#canvas-draft').mousedown(e => {
   const mouseLoc = [e.offsetX, e.offsetY];

--- a/scripts/circle-fill.js
+++ b/scripts/circle-fill.js
@@ -25,6 +25,7 @@ class CircleFill extends PaintFunction{
         this.contextReal.beginPath();
         this.contextReal.arc(this.origX, this.origY, this.radius, 0, 2*Math.PI, false);
         this.contextReal.fill();
+        saveImage(canvasReal);
     }
     onMouseLeave(){}
     onMouseEnter(){}

--- a/scripts/circle.js
+++ b/scripts/circle.js
@@ -1,37 +1,35 @@
-class Circle extends PaintFunction{
-    constructor(contextReal,contextDraft){
+class Circle extends PaintFunction {
+    constructor(contextReal, contextDraft) {
         super();
         this.contextReal = contextReal;
-        this.contextDraft = contextDraft;            
+        this.contextDraft = contextDraft;
     }
-    
-    onMouseDown(coord, event, style){
+
+    onMouseDown(coord, event, style) {
         this.contextDraft.strokeStyle = style.curCol.stroke;
-        this.contextDraft.lineWidth = canvasSettings.brushSize;
+        this.contextDraft.lineWidth = style.brushSize;
 
         this.contextReal.strokeStyle = style.curCol.stroke;
-        this.contextReal.lineWidth = canvasSettings.brushSize;
+        this.contextReal.lineWidth = style.brushSize;
 
         this.origX = coord[0];
         this.origY = coord[1];
     }
-    onDragging(coord, event){
-        this.contextDraft.clearRect(0,0,canvasDraft.width,canvasDraft.height);
-        this.contextReal.lineWidth = canvasSettings.brushSize;
-        
-        this.radius = Math.sqrt( Math.pow(this.origX - coord[0] , 2) + Math.pow(this.origY - coord[1], 2) );
+    onDragging(coord, event) {
+        this.contextDraft.clearRect(0, 0, canvasDraft.width, canvasDraft.height);
+        this.radius = Math.sqrt(Math.pow(this.origX - coord[0], 2) + Math.pow(this.origY - coord[1], 2));
         this.contextDraft.beginPath();
-        this.contextDraft.arc(this.origX, this.origY, this.radius, 0, 2*Math.PI, false);
+        this.contextDraft.arc(this.origX, this.origY, this.radius, 0, 2 * Math.PI, false);
         this.contextDraft.stroke();
     }
 
-    onMouseMove(){}
-    onMouseUp(coord, event){
-        this.contextDraft.clearRect(0,0,canvasDraft.width,canvasDraft.height);
+    onMouseMove() {}
+    onMouseUp(coord, event) {
+        this.contextDraft.clearRect(0, 0, canvasDraft.width, canvasDraft.height);
         this.contextReal.beginPath();
-        this.contextReal.arc(this.origX, this.origY, this.radius, 0, 2*Math.PI, false);
+        this.contextReal.arc(this.origX, this.origY, this.radius, 0, 2 * Math.PI, false);
         this.contextReal.stroke();
     }
-    onMouseLeave(){}
-    onMouseEnter(){}
+    onMouseLeave() {}
+    onMouseEnter() {}
 }

--- a/scripts/eraser.js
+++ b/scripts/eraser.js
@@ -6,8 +6,7 @@ class Eraser extends PaintFunction {
 
     onMouseDown(coord, event, style) {
         this.context.strokeStyle = style.curCol.bgc;
-        this.context.lineWidth = canvasSettings.brushSize;
-        
+        this.context.lineWidth = style.brushSize;
         this.context.beginPath();
         this.context.moveTo(coord[0], coord[1]);
         this.draw(coord[0], coord[1]);
@@ -16,10 +15,10 @@ class Eraser extends PaintFunction {
         this.draw(coord[0], coord[1]);
     }
 
-    onMouseMove() { }
-    onMouseUp() { }
-    onMouseLeave() { }
-    onMouseEnter() { }
+    onMouseMove() {}
+    onMouseUp() {}
+    onMouseLeave() {}
+    onMouseEnter() {}
 
     draw(x, y) {
         this.context.lineTo(x, y);

--- a/scripts/image-drawer.js
+++ b/scripts/image-drawer.js
@@ -1,0 +1,3 @@
+$("#dr-img").on("change",function(e){
+    console.log(URL.createObjectURL($("#dr-img")['0'].files['0']));
+})

--- a/scripts/image-drawer.js
+++ b/scripts/image-drawer.js
@@ -1,3 +1,49 @@
-$("#dr-img").on("change",function(e){
-    console.log(URL.createObjectURL($("#dr-img")['0'].files['0']));
+// Initiate image for storage purpose
+let deImage = document.createElement("img");
+
+// Trigger img storage when load image by users
+$("#dr-img").on("change", function (e) {
+    deImage.src = URL.createObjectURL($("#dr-img")['0'].files['0']);
 })
+
+// Instantiate
+// Note: the only function that is accessing global variable because of other functions
+class ImageFill extends PaintFunction {
+    constructor(contextReal, contextDraft) {
+        super();
+        this.contextReal = contextReal;
+        this.contextDraft = contextDraft;
+    }
+
+    onMouseDown(coord, event, style) {
+        this.origX = coord[0];
+        this.origY = coord[1];
+    }
+    onDragging(coord, event, style) {
+        this.contextDraft.clearRect(0, 0, canvasDraft.width, canvasDraft.height);
+        this.contextDraft.drawImage(
+            deImage,
+            this.origX,
+            this.origY,
+            coord[0] - this.origX,
+            coord[1] - this.origY
+        );
+    }
+
+    onMouseMove() {}
+    onMouseUp(coord, event, style) {
+        this.contextDraft.clearRect(0, 0, canvasDraft.width, canvasDraft.height);
+        this.contextReal.drawImage(
+            deImage,
+            this.origX,
+            this.origY,
+            coord[0] - this.origX,
+            coord[1] - this.origY
+        );
+    }
+    onMouseLeave() {}
+    onMouseEnter() {}
+}
+
+
+

--- a/scripts/image-storage.js
+++ b/scripts/image-storage.js
@@ -1,3 +1,5 @@
+let storeImg = [0];
+
 let saveImage = canvas => {
   canvas.toBlob(blob => {
     let newImg = document.createElement("img"),
@@ -5,9 +7,7 @@ let saveImage = canvas => {
 
     newImg.src = url;
     newImg.onload = () => {
-      // writeTempImg(newImg);
     };
-
     writeTempImg(newImg);
   });
 };
@@ -18,5 +18,27 @@ function retriveImage(img) {
 }
 
 function writeTempImg(imgElement) {
-  storeImg = imgElement;
+  storeImg.push(imgElement);
+  console.log(storeImg);
 }
+
+
+let map = {};
+$(window).on("keydown", (e) => {
+  map[e.keyCode] = e.type == "keydown";
+  if (map[17] && map[90]) {
+    retriveImage(storeImg[storeImg.length-2]);
+    storeImg.pop();
+    map = {};
+    return false;
+  }
+})
+
+
+
+$("#test").click(() => {
+  saveImage(canvasReal);
+});
+$("#retrive").click(() => {
+  retriveImage(storeImg);
+});

--- a/scripts/image-storage.js
+++ b/scripts/image-storage.js
@@ -8,7 +8,6 @@ let saveImage = canvas => {
   canvas.toBlob(blob => {
     let newImg = document.createElement("img"),
       url = URL.createObjectURL(blob);
-
     newImg.src = url;
     newImg.onload = () => {
     };
@@ -18,6 +17,7 @@ let saveImage = canvas => {
 
 function retriveImage(img) {
   contextReal.clearRect(0, 0, 800, 500);
+  console.log(img);
   contextReal.drawImage(img, 0, 0);
 }
 

--- a/scripts/image-storage.js
+++ b/scripts/image-storage.js
@@ -1,4 +1,8 @@
-let storeImg = [0];
+let storeImg = [];
+
+$(document).ready(()=>{
+  saveImage(canvasReal);
+})
 
 let saveImage = canvas => {
   canvas.toBlob(blob => {
@@ -26,9 +30,11 @@ function writeTempImg(imgElement) {
 let map = {};
 $(window).on("keydown", (e) => {
   map[e.keyCode] = e.type == "keydown";
-  if (map[17] && map[90]) {
+  if (map[17] && map[90] && storeImg.length>0) {
     retriveImage(storeImg[storeImg.length-2]);
     storeImg.pop();
+    console.log("after changing the image array");
+    console.log(storeImg);
     map = {};
     return false;
   }

--- a/scripts/line.js
+++ b/scripts/line.js
@@ -8,11 +8,11 @@ class Line extends PaintFunction {
     onMouseDown(coord, event, style) {
         this.contextDraft.strokeStyle = style.curCol.stroke;
         this.contextDraft.lineJoin = style.joint;
-        this.contextDraft.lineWidth = canvasSettings.brushSize;
+        this.contextDraft.lineWidth = style.brushSize;
 
         this.contextReal.strokeStyle = style.curCol.stroke;
         this.contextReal.lineJoin = style.joint;
-        this.contextReal.lineWidth = canvasSettings.brushSize;
+        this.contextReal.lineWidth = style.brushSize;
         
 
         this.origX = coord[0];

--- a/scripts/line.js
+++ b/scripts/line.js
@@ -32,6 +32,7 @@ class Line extends PaintFunction {
         this.contextReal.lineTo(coord[0], coord[1]);
         this.contextReal.closePath();
         this.contextReal.stroke();
+        saveImage(canvasReal);
     }
 
     onMouseLeave() { }

--- a/scripts/pencil.js
+++ b/scripts/pencil.js
@@ -7,7 +7,7 @@ class Pencil extends PaintFunction {
     onMouseDown(coord, event, style) {
         this.context.strokeStyle = style.curCol.stroke;
         this.context.lineJoin = style.joint;
-        this.context.lineWidth = style.strokeWth;
+        this.context.lineWidth = canvasSettings.brushSize;
         this.context.beginPath();
         this.context.moveTo(coord[0], coord[1]);
         this.draw(coord[0], coord[1]);

--- a/scripts/pencil.js
+++ b/scripts/pencil.js
@@ -7,7 +7,7 @@ class Pencil extends PaintFunction {
     onMouseDown(coord, event, style) {
         this.context.strokeStyle = style.curCol.stroke;
         this.context.lineJoin = style.joint;
-        this.context.lineWidth = canvasSettings.brushSize;
+        this.context.lineWidth = style.brushSize;
         this.context.beginPath();
         this.context.moveTo(coord[0], coord[1]);
         this.draw(coord[0], coord[1]);

--- a/scripts/polygon.js
+++ b/scripts/polygon.js
@@ -9,11 +9,11 @@ class Polygon extends PaintFunction {
     onMouseDown(coord, event, style) {
         this.contextDraft.strokeStyle = style.curCol.stroke;
         this.contextDraft.lineJoin = style.joint;
-        this.contextDraft.lineWidth = canvasSettings.brushSize;
+        this.contextDraft.lineWidth = style.brushSize;
         
         this.contextReal.strokeStyle = style.curCol.stroke;
         this.contextReal.lineJoin = style.joint;
-        this.contextReal.lineWidth = canvasSettings.brushSize;
+        this.contextReal.lineWidth = style.brushSize;
 
         if (check = false) { 
             this.origX = coord[0];

--- a/scripts/rectangle.js
+++ b/scripts/rectangle.js
@@ -7,17 +7,17 @@ class Rectangle extends PaintFunction {
 
   onMouseDown(coord, event, style) {
     this.contextDraft.strokeStyle = style.curCol.stroke;
-    this.contextDraft.lineWidth = canvasSettings.brushSize;
+    this.contextDraft.lineWidth = style.brushSize;
 
     this.contextReal.strokeStyle = style.curCol.stroke;
-    this.contextReal.lineWidth = canvasSettings.brushSize;
+    this.contextReal.lineWidth = style.brushSize;
     
     this.origX = coord[0];
     this.origY = coord[1];
   }
   onDragging(coord, event, style) {
     this.contextDraft.strokeStyle = style.curCol.stroke;
-    this.contextDraft.lineWidth = canvasSettings.brushSize;
+    this.contextDraft.lineWidth = style.brushSize;
     this.contextDraft.clearRect(0, 0, canvasDraft.width, canvasDraft.height);
     this.contextDraft.strokeRect(
       this.origX,


### PR DESCRIPTION
Image drawer, slightly cleaned colour picker, converted into arguments instead of accessing global variables, relocate inline scripts into canvas-commons

- Added image drawer: user upload image then draw the image pattern
- Converting into arguments for f(x) to perform actions instead of having the functions accessing global variables
- Relocating all the inline scripts from index.html into canvas-common.js